### PR TITLE
Update pinpoint-import.yaml

### DIFF
--- a/pinpoint-import.yaml
+++ b/pinpoint-import.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt ImportSegmentLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 60
       Environment:
         Variables:
@@ -162,7 +162,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt ImportSegmentStatusLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 60
       Environment:
         Variables:
@@ -407,7 +407,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt S3NotificationLambdaFunctionRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 30
       Environment:
         Variables:
@@ -508,7 +508,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt CustomResourceLambdaFunctionRole.Arn
-      Runtime: python3.7
+      Runtime: python3.11
       Timeout: 50
       Code:
         ZipFile: |


### PR DESCRIPTION
Update the Python version to 3.11 for the Lambda Runtime to meet the new Lambda runtime version requirement.

*Issue #, if available:*
Lambda function removed the support for Python 3.7 as runtime.

*Description of changes:*
Updated the Lambda runtime to Python 3.11 in the YAML template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
